### PR TITLE
[07-common-problems] update text referring to bug in bhmm

### DIFF
--- a/notebooks/07-common-problems.ipynb
+++ b/notebooks/07-common-problems.ipynb
@@ -273,13 +273,13 @@
    "source": [
     "#### What do we see?\n",
     "\n",
-    "1) With the fine discretization, we observe some timescales that are converged. These are most probably processes within one of the wells as we say previously.\n",
+    "1) With the fine discretization, we observe some timescales that are converged. These are most probably processes within one of the wells as we saw previously.\n",
     "\n",
-    "2) The poor discretization introduces a large error and describes short visits to the other basin.\n",
+    "2) The poor discretization induces a large error and describes artificial short visits to the other basin.\n",
     "\n",
     "3) The timescales in the poor discretization are much higher but not converged. \n",
     "\n",
-    "The reason for the high timescales of the poor discretization are in fact the artificial cross-over events created by the poor discretization. This process was not actually sampled and is an artifact of bad clustering. Let's look at it in more detail anyway and even compute metastable states with a PCCA+."
+    "The reason for the high timescales in 3) are in fact the artificial cross-over events created by the poor discretization. This process was not actually sampled and is an artifact of bad clustering. Let's look at it in more detail anyway and even compute metastable states with a PCCA+."
    ]
   },
   {
@@ -330,7 +330,25 @@
     "We observe that the first eigenvector represents a process that does not exist, i.e. is an artifact. Nevertheless, the PCCA+ algorithm can separate metastable states in a way we would expect. It finds the two disconnected states. However, the stationary distribution yields arbitrary results. \n",
     "\n",
     "#### How to detect disconnectivity?\n",
-    "Generally, hidden Markov models (HMMs) are much more reliable because they come with an additional layer of hidden states. Cross-over events are thus unlikely to be counted as \"real\" transitions. Thus, it is a good idea to estimate an HMM."
+    "Generally, hidden Markov models (HMMs) are much more reliable because they come with an additional layer of hidden states. Cross-over events are thus unlikely to be counted as \"real\" transitions. Thus, it is a good idea to estimate an HMM. What happens if we take our previously estimated MSM and coarse grain it into two states with the HMM method? It is important to note that the HMM estimation is initialized from the PCCA+ metastable states that we already analyzed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "hmm = m.coarse_grain(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are getting an error message which already explains what is going wrong, i.e. that (macro-) states are not connected and thus no unique stationary distribution can be estimated. This is equivalent to having two eigenvalues of magnitude 1 or an implied timescale of infinity which is what we observe in the implied timescales plot."
    ]
   },
   {
@@ -341,7 +359,7 @@
    },
    "outputs": [],
    "source": [
-    "its = pyemma.msm.timescales_hmsm(cl_bad.dtrajs, 2, lags=[1, 10, 100, 200, 300, 500, 800, 1000])\n",
+    "its = pyemma.msm.timescales_hmsm(cl_bad.dtrajs, 2, lags=[1, 3, 4, 10, 100])\n",
     "pyemma.plots.plot_implied_timescales(its, marker='o', ylog=True)"
    ]
   },
@@ -349,98 +367,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we see, most of the requested timescales could not be computed because the underlying HMM is disconnected (a.k.a. there are multiple eigenvalues with magnitude one). What happens if we take our previously estimated MSM and coarse grain it into two states with the HMM method?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## TODO: something wrong with pyEMMA behavior. #1312."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hmm = msm.coarse_grain(2)\n",
-    "print('Implied timescale: ', hmm.timescales())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We are getting an implied timescale which is infinity. This in a sense corresponds to the original, unconverged MSM time scale displayed above. The HMM captures the value that was underestimated by the MSM. Let's compare this to the fine state space discretization by estimating a new HMM.\n",
+    "As we see, the requested timescales above 4 steps could not be computed because the underlying HMM is disconnected, i.e. the corresponding timescales are infinity. The implied timescales that could be computed are most likely the same process that we observed from the fine clustering before, i.e. jumps within one basin.\n",
     "\n",
-    "What does this mean? The HMM estimates that the state does not decay, i.e. the time it takes to fall back to the equilibrium distribution is infinity. This means that the disconnectivity has been detected."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "msm = pyemma.msm.estimate_markov_model(cl_fine.dtrajs, 200)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hmm_finediscretization = pyemma.msm.estimate_hidden_markov_model(cl_fine.dtrajs, 2, 200)\n",
-    "print('Implied timescale: ', hmm.timescales())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We see that still that the implied time scale is infinity. That means that the effect of the bad discretization on the HMM estimation is not visible in this example. We find that the metastable distribution is similar to the one estimated by PCCA+ and separates the two potential wells independently of the quality of the discretization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, ax = plt.subplots(1, 1)\n",
-    "index_order = np.argsort(cl_bad.clustercenters[:, 0])\n",
-    "for n, metastable_distribution in enumerate(hmm.metastable_distributions):\n",
-    "    ax.step(\n",
-    "        cl_bad.clustercenters[index_order, 0],\n",
-    "        metastable_distribution[index_order],\n",
-    "        ':', \n",
-    "        where='mid',\n",
-    "        color='C%d' % n,\n",
-    "        label='HMM state %d' % n)\n",
-    "index_order = np.argsort(cl_fine.clustercenters[:, 0])\n",
-    "for n, metastable_distribution in enumerate(hmm_finediscretization.metastable_distributions):\n",
-    "    ax.step(\n",
-    "        cl_fine.clustercenters[index_order, 0],\n",
-    "        metastable_distribution[index_order],\n",
-    "        ':', \n",
-    "        where='mid',\n",
-    "        color='C%d' % (1 - n))\n",
-    "tx = ax.twinx()\n",
-    "tx.hist(np.concatenate(trjs), bins=30, alpha=.33)\n",
-    "tx.set_yticklabels([])\n",
-    "tx.set_yticks([])\n",
-    "fig.legend()\n",
-    "fig.tight_layout()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Please note that the metastable state number is arbitrary."
+    "In general, is is a non-trivial problem to show that processes were not sampled reversibly. In our experience, HMMs are a good choice here, even though situations can occur where they might not detect the problem as easy as here. "
    ]
   },
   {
@@ -751,7 +680,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Don't merge for now. Requires bhmm update before behavior corresponds to text i.e. actual error messages pop up. 

PR removes the \#TODO about HMM of disconnected macrostates.