### PR TITLE
added workaround in launcher for conda-pip-mixed nglview installs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,3 @@ or if you have installed the package directly
 conda remove pyemma_tutorials
 ```
 
-### Troubleshooting
-
-* No molecular structure is displayed:
-  This can be caused by the leftovers of pip installations of NGLView. Please search your home directory for the following:
-  ``` bash
-  rm -rf ~/.local/share/jupyter/nbextensions/nglview-js-widgets/  # if you have it
-  # try to find in `$HOME/Library/Jupyter` too
-  ```
-  More details can be found here:
-  - https://github.com/arose/nglview/issues/696#issuecomment-332850270
-  - https://github.com/arose/nglview/issues/718#issuecomment-346041897

--- a/notebooks/.gitignore
+++ b/notebooks/.gitignore
@@ -1,1 +1,2 @@
 data/*
+*.pyemma

--- a/pyemma_tutorials/cli.py
+++ b/pyemma_tutorials/cli.py
@@ -1,13 +1,26 @@
 
+def _nglview_pip_installed_workaround():
+    # This is a workaround for people having a pip installation of nglview. The XDG_DATA_DIR is being searched for the
+    # javascript nbextensions. This would cause mixing up different versions of the widget.
+    # Further info:
+    # https://jupyter.readthedocs.io/en/latest/migrating.html?highlight=data-dir#finding-the-location-of-important-files
+    # https://github.com/arose/nglview/issues/696#issuecomment-332850270
+    # https://github.com/arose/nglview/issues/718#issuecomment-346041897
+    import os
+    os.environ['JUPYTER_DATA_DIR'] = 'non-sense'
+    assert os.getenv('JUPYTER_DATA_DIR', False)
+
 
 def main():
     from notebook.notebookapp import main as main_
-    from .util import notebook_location, configs_location
+    from .util import configs_location
 
     # main eats, argv list and kwargs
     notebook_cfg, notebook_cfg_json = configs_location()
 
-    argv = ['--config=%s' % notebook_cfg, '--config=%s' % notebook_cfg_json ]
+    _nglview_pip_installed_workaround()
+
+    argv = ['--config=%s' % notebook_cfg, '--config=%s' % notebook_cfg_json]
     print('arguments:', argv)
     main_(argv=argv)
 


### PR DESCRIPTION
by setting the environment variable JUPYTER_DATA_DIR to something else then the home directory, we can avoid having the hassle of mixing pip and conda installed versions of nglview (the javascripts).

fyi @gph82, @hainm 