### PR TITLE
observable notebook quick revision

### DIFF
--- a/notebooks/06-expectations-and-observables.ipynb
+++ b/notebooks/06-expectations-and-observables.ipynb
@@ -146,9 +146,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the case of nonequilibrium data, one might wish to compute a reweighted instead of the empirical distribution. To do so, we have to pass the output of `msm.trajectory_weights()` as weights for the histogramming as shown in the left panel below.\n",
-    "\n",
-    "Be careful not to use the discrete probabilities as weights: you would then reweight without taking the empirical distribution of the data into account (right panel)."
+    "In the case of nonequilibrium data, one might wish to compute a reweighted instead of the empirical distribution. To do so, we have to pass the output of `msm.trajectory_weights()` as weights for the histogramming as shown in the left panel below."
    ]
   },
   {
@@ -159,8 +157,8 @@
    "source": [
     "msm_trajectory_weights = msm.trajectory_weights()[0]\n",
     "\n",
-    "fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharex=True, sharey=True)\n",
-    "axes[0].hist(\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.hist(\n",
     "    observable_traj,\n",
     "    bins=128,\n",
     "    weights=msm_trajectory_weights,\n",
@@ -169,36 +167,26 @@
     "    color='C0',\n",
     "    lw=2,\n",
     "    density=True)\n",
-    "axes[1].hist(\n",
+    "ax.hist(\n",
     "    observable_traj,\n",
     "    bins=128,\n",
-    "    weights=msm.pi[dtrajs_concatenated],\n",
     "    histtype='step',\n",
-    "    label=r'empirical $\\times$ reweighted',\n",
-    "    color='C1',\n",
-    "    lw=2,\n",
+    "    label='empirical',\n",
+    "    color='k',\n",
     "    density=True)\n",
-    "for ax in axes.flat:\n",
-    "    ax.hist(\n",
-    "        observable_traj,\n",
-    "        bins=128,\n",
-    "        histtype='step',\n",
-    "        label='empirical',\n",
-    "        color='k',\n",
-    "        density=True)\n",
-    "    ax.set_xlabel('$o(x, y)$')\n",
-    "    ax.legend()\n",
-    "axes[0].set_ylabel('probability')\n",
-    "fig.tight_layout()"
+    "ax.set_xlabel('$o(x, y)$')\n",
+    "ax.legend()\n",
+    "ax.set_ylabel('probability');"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the present case, the data is well equilibrated and we see no difference between the empirical and the properly reweighted distribution. The (incorrect) approach using only the MSM's stationary weights neglects the implicit distribution of the data points and, thus, yields a visibly different result.\n",
+    "In the present case, the data is well equilibrated and we see no difference between the empirical and the properly reweighted distribution. \n",
     "\n",
     "In the experiment we have measured this observable to be equal to $3.5$ a.u. In order to compute this experimental observable from our MSM from above, we need to compute the experimental observable for each of our Markov states by taking the average within the Markov state:\n",
+    "\n",
     "$$ \\mathbf{o}_i = \\frac{1}{N_{a \\in S_i} } \\sum_{a \\in S_i} o(a_x,a_y) $$"
    ]
   },

--- a/notebooks/06-expectations-and-observables.ipynb
+++ b/notebooks/06-expectations-and-observables.ipynb
@@ -647,7 +647,7 @@
     "with $\\mathbf{\\hat p_0}=\\boldsymbol{\\Pi}^{-1}\\mathbf{p_0}$.\n",
     "\n",
     "\n",
-    "In PyEMMA, the MSM and HMM objects have the methods `correlation` and `relaxation` which implement calculation of auto-correlation in equilibrium and relaxation from a specified nonequilibrium distribution. Many experimental observables do not measure correlation functions directly but some quantity which depends on a correlation function, or its Fourier transform ([2-3](#References)). In many of these cases it is possible to obtain analytical expressions of the observable which depends only on the amplitudes $(\\mathbf{o}^T\\boldsymbol{\\phi}_i)^2$ and time-scales $t_i$, quantities which can be computed given $\\mathbf{o}$ using the `fingerprint_correlation` and `fingerprint_relaxation` methods of the MSM or HMSM objects. \n",
+    "In PyEMMA, the MSM and HMM objects have the methods `correlation` and `relaxation` which implement calculation of auto-correlation in equilibrium and relaxation from a specified nonequilibrium distribution. Many experimental observables do not measure correlation functions directly but some quantity which depends on a correlation function, or its Fourier transform ([2-3](#References)). In many of these cases it is possible to obtain analytical expressions of the observable which depends only on the amplitudes $(\\mathbf{o}^T\\boldsymbol{\\phi}_i)^2$ and time-scales $t_i$, quantities which can be computed given $\\mathbf{o}$ using the `fingerprint_correlation` and `fingerprint_relaxation` methods of the MSM or HMM objects. \n",
     "\n",
     "We here compute the auto-correlation function of the distance between the amide and alpha protons."
    ]

--- a/notebooks/06-expectations-and-observables.ipynb
+++ b/notebooks/06-expectations-and-observables.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\"><img alt=\"Creative Commons Licence\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by/4.0/88x31.png\" title='This work is licensed under a Creative Commons Attribution 4.0 International License.' align=\"right\"/></a>\n",
     "\n",
-    "This notebook covers the calculation of stationary and dynamic expectation values. These quantities include ensemble averaged observales measurable by experiments, correlation function, and spectral densities.\n",
+    "This notebook covers the calculation of stationary and dynamic expectation values. These quantities include ensemble averaged observables measurable by experiments, correlation functions, and spectral densities.\n",
     "\n",
     "Maintainers: [@cwehmeyer](https://github.com/cwehmeyer), [@marscher](https://github.com/marscher), [@psolsson](https://github.com/psolsson)\n",
     "\n",
@@ -20,12 +20,12 @@
     "\n",
     "We recall that a (stationary) ensemble average $\\langle O \\rangle$ is defined by a Boltzmann-weighted average with the potential energy function $E(\\cdot)$:\n",
     "$$ \\langle O \\rangle = \\mathcal{Z}^{-1}\\int_{\\Omega}\\;\\mathrm{d}x\\, o(x)\\exp(-\\beta E(x)) $$\n",
-    "where $x \\in \\Omega$ is a molecular configuration and $o(\\cdot)$ is a function which relates the atomic-coordinates of a configuration to a time-independent, microscopic observable. The function $o(\\cdot)$ is often called a 'forward model', often involves computing distances or angles between particular atoms. For MSMs we have discretized our configurational space $\\Omega$, which simplifies the expression to the sum\n",
+    "where $x \\in \\Omega$ is a molecular configuration and $o(\\cdot)$ is a function which relates the atomic coordinates of a configuration to a time-independent, microscopic observable. The function $o(\\cdot)$ is often called a 'forward model'; it frequently involves computing distances or angles between particular atoms. For MSMs we have discretized our configurational space $\\Omega$, which simplifies the expression to the sum\n",
     "\n",
     "$$ \\langle O \\rangle = \\sum_i \\pi_i \\mathbf{o}_i $$\n",
     "\n",
-    "where $\\pi_i$ corresponding the integrated probability density of the segment of configuration space assigned to Markov state $i$. The Boltzmann distribution, or stationary distribution, $\\boldsymbol{\\pi}$ is computed as the left-eigenvector corresponding to the eigenvalue of 1 of the MSM transition  matrix. The mapping of the experimental observable is mapped on to the Markov states as the vector $o$ with elements,\n",
-    "$$ \\mathbf{o}_i = \\frac{1}{\\pi_i\\mathcal{Z}} \\int_{x\\in S_i} \\mathrm{d}x\\, o(x)\\exp(-\\beta E(x)) $$"
+    "where $\\pi_i$ corresponds to the integrated probability density of the segment of configuration space assigned to Markov state $i$. The stationary distribution $\\boldsymbol{\\pi}$ is computed as the left-eigenvector corresponding to the eigenvalue of $1$ of the MSM transition  matrix. The mapping of the experimental observable is mapped onto the Markov states as the vector $o$ with elements,\n",
+    "$$ \\mathbf{o}_i = \\frac{1}{\\pi_i\\mathcal{Z}} \\int_{x\\in S_i} \\mathrm{d}x\\, o(x)\\exp(-\\beta E(x)). $$"
    ]
   },
   {
@@ -99,9 +99,11 @@
    "metadata": {},
    "source": [
     "### An imaginary experiment\n",
-    "Let us first take a look at stationary ensemble averages for this system. Say the simulation data above represents a protein switching between two meta-stable configurations, perfectly separated by $y$-coordinate. Imagine then that by inspection of the two meta-stable configurations we have designed an experiment which allows us to measure an observable defined by:\n",
+    "Let us first take a look at stationary ensemble averages for this system. Say the simulation data above represents a protein switching between two metastable configurations, perfectly separated by the $y$-coordinate. Imagine then that by inspection of the two metastable configurations, we have designed an experiment which allows us to measure an observable defined by\n",
+    "\n",
     "$$ o(x,y) = 0.5x + y + 4. $$\n",
-    "We compute the observables for the entire simulation trajectory, inspect the empirical histograms and the histograms of the meta-stable sets identified by a two-state PCCA++ analysis."
+    "\n",
+    "We compute the observables for the entire simulation trajectory, inspect the empirical histograms and the histograms of the metastable sets identified by a two-state PCCA++ analysis."
    ]
   },
   {
@@ -146,7 +148,7 @@
    "source": [
     "In the case of nonequilibrium data, one might wish to compute a reweighted instead of the empirical distribution. To do so, we have to pass the output of `msm.trajectory_weights()` as weights for the histogramming as shown in the left panel below.\n",
     "\n",
-    "Be careful not to use the discrete probabilities as weights: you would then reweight without taking the empiricial distribution of the data into account (right panel)."
+    "Be careful not to use the discrete probabilities as weights: you would then reweight without taking the empirical distribution of the data into account (right panel)."
    ]
   },
   {
@@ -262,7 +264,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These plots illustrate how we lose some resolution when in our observable when clustering the data, since the observable is considered constant at the sample average of the all simulation frames assigned to a given cluster. With our vector of observables for our experiment we can compute the ensemble average by using the `expectation` method of our MSM:"
+    "These plots illustrate how we lose some resolution in our observable when clustering the data. The reason is that observable is considered constant at the sample average of all simulation frames assigned to a given cluster. With our vector of observables for our experiment we can compute the ensemble average by using the `expectation` method of our MSM:"
    ]
   },
   {
@@ -282,7 +284,7 @@
     "We observe that our Markov model has a small deviation from the \"experimental\" value which we, in a practical case, would have to gauge against imprecisions in the prediction of the observable (some contributions include: approximations involving the forward model, the dicretization/projection error and limited sampling) and the experimental uncertainty.\n",
     "\n",
     "### Computing observables with error-bars\n",
-    "If we have estimated a Bayesian MSM or HMSM, we can compute limited sampling contribution to our experimental observable prediction by computing sample averages and confidence intervals."
+    "If we have estimated a Bayesian MSM or HMM, we can compute limited sampling contribution to our experimental observable prediction by computing sample averages and confidence intervals."
    ]
   },
   {
@@ -309,7 +311,7 @@
     "$$o_2(x,y) = (y+2)^2 + x$$\n",
     "\n",
     "#### Exercise 1\n",
-    "Compute the difference of our MSM prediction of this observable to the experimental value of $5\\,\\mathrm{a.u.}$. Compute the sample average and confidence interval from our Bayesian MSM. Is the experimental value within within the 95% confidence interval?"
+    "Compute the difference of our MSM prediction of this observable to the experimental value of $5$ a.u. Compute the sample average and confidence interval from our Bayesian MSM. Is the experimental value within within the 95% confidence interval?"
    ]
   },
   {
@@ -398,14 +400,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In cases like these, we can use the Augmented Markov models (AMMs) to estimate MSMs which optimally balance experimental and simulation data (1). A walkthrough tutorial can be found here: http://www.emma-project.org/latest/generated/augmented_markov_model_walkthrough.html"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Case 2: low-dimensional molecular dynamics data (alanine dipeptide)"
+    "In cases like these, we can use the Augmented Markov models (AMMs) to estimate MSMs which optimally balance experimental and simulation data (1). A walkthrough tutorial can be found here: http://www.emma-project.org/latest/generated/augmented_markov_model_walkthrough.html\n",
+    "\n",
+    "## Case 2: low-dimensional molecular dynamics data (alanine dipeptide)\n",
+    "\n",
+    "\n",
+    "We fetch the alanine dipeptide data set, load the backbone torsions into memory, discretize the full space using $k$-means clustering, visualize the marginal and joint distributions of both components as well as the cluster centers, and show the ITS convergence:"
    ]
   },
   {
@@ -441,6 +441,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We estimate a Markov model at a lagtime of $10$ ps and do a Chapman-Kolmogorov validation:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -467,11 +474,12 @@
    "metadata": {},
    "source": [
     "## Using PyEMMA `coordinates` module to aid computation of molecular observables\n",
-    "We now turn to 2-Ala. In this case we want make use of features computed from molecular trajectory with the help of the the PyEMMA `coordinates` module. For this small molecular systems we will focus on the $^1H^N-^1H^{\\alpha}$   $^3J$-coupling, a NMR parameter which is sensitive to the dihedral between the plane spanned by the inter-atomic vectors of H-N and N-C$\\alpha$ and the plane spanned by H$\\alpha$-C$\\alpha$ and C$\\alpha$-N. A common forward model to back-calculate $^3J$-couplings from a molecular configurations is called the Karplus equation:\n",
+    "\n",
+    "In this case we want to make use of features computed from molecular trajectory with the help of the PyEMMA `coordinates` module. For this small molecular systems we will focus on the $^1H^N-^1H^{\\alpha}$   $^3J$-coupling, a NMR parameter which is sensitive to the dihedral between the plane spanned by the inter-atomic vectors of H-N and N-C$\\alpha$ and the plane spanned by H$\\alpha$-C$\\alpha$ and C$\\alpha$-N. A common forward model to back-calculate $^3J$-couplings from a molecular configurations is called the Karplus equation\n",
     "\n",
     "$$ ^3J(\\theta) = A\\cos^2{\\theta}+B\\cos{\\theta} + C, $$\n",
     "\n",
-    "Where the (Karplus) parameters $A$, $B$ and $C$ are empirical constants which depend on the properties of the atoms involved in the observable. Here we use the values $A=8.754 \\, \\mathrm{Hz}$, $B=−1.222\\, \\mathrm{Hz}$ and $C=0.111\\, \\mathrm{Hz}$."
+    "where the (Karplus) parameters $A$, $B$ and $C$ are empirical constants which depend on the properties of the atoms involved in the observable. Here, we use the values $A=8.754 \\, \\mathrm{Hz}$, $B=−1.222\\, \\mathrm{Hz}$ and $C=0.111\\, \\mathrm{Hz}$."
    ]
   },
   {
@@ -507,7 +515,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us visualize this observable along with the stationary distribution as above"
+    "Let us visualize this observable along with the stationary distribution as above:"
    ]
   },
   {
@@ -634,7 +642,7 @@
    "metadata": {},
    "source": [
     "## Dynamic/kinetic experimental observables\n",
-    "Experimentally we can measure kinetic information through time-correlation functions or spectral densities. Markov models are probabilistic models of the dynamics, so if we have an ergodic dynamics described by a Markov model we can compute the equilibrium time-correlation functions using\n",
+    "We can measure kinetic information experimentally through time-correlation functions or spectral densities. Markov models are probabilistic models of the dynamics, i.e. if we have an ergodic dynamics described by a Markov model, we can compute the equilibrium time-correlation functions using\n",
     "\n",
     "$$ \\mathbb{E}[o(x_{t})o(x_{t+k\\tau})] = \\underbrace{\\mathbf{o}^T}_{\\text{transpose of vector of observables in Markov states}} \\overbrace{\\boldsymbol{\\Pi}}^{\\text{diagonal matrix of stationary distribution}} \\underbrace{\\mathbf{P}^k_{\\tau}}_{\\text{transition matrix}} \\overbrace{\\mathbf{o}}^{\\text{vector of observables in Markov states}} $$\n",
     "\n",
@@ -642,16 +650,16 @@
     "\n",
     "$$ \\mathbb{E}[o(x_{t})o(x_{t+k\\tau})] = (\\mathbf{o}^T\\boldsymbol{\\pi})^2 + \\sum^N_{i=2} \\exp\\left(-\\frac{k\\tau}{t_i}\\right)(\\mathbf{o}^T\\boldsymbol{\\phi}_i)^2 $$\n",
     "\n",
-    "by using the spectral decomposition of the transition matrix ([1](#References)). $\\phi_i$ is the $i$th left-eigenvector of $\\mathbf{P}_{\\tau}$, with the associated implied time-scale $t_i$. We see that the auto-correlation functions take the form of a multi-exponential decay. \n",
+    "by using the spectral decomposition of the transition matrix ([1](#References)). $\\phi_i$ is the $i$th left eigenvector of $\\mathbf{P}_{\\tau}$, with the associated implied timescale $t_i$. We see that the auto-correlation functions take the form of a multi-exponential decay. \n",
     "\n",
-    "If we now consider relaxation from an non-equilibrium state $\\mathbf{p_0}$, which can achieved by T-jump or P-jump experiments. In this case the initial distribution and final ensembles are not the same ($\\mathbf{p_0}$ and $\\boldsymbol{\\pi}$) and so the auto-correlation becomes:\n",
+    "We now consider relaxation from a nonequilibrium state $\\mathbf{p_0}$, which can be achieved by T-jump or P-jump experiments. In this case, the initial distribution and final ensembles are not the same ($\\mathbf{p_0}$ and $\\boldsymbol{\\pi}$) and so the auto-correlation becomes:\n",
     "\n",
     "$$ \\mathbb{E}[o(x_{t})o(x_{t+k\\tau})] = (\\mathbf{\\hat p_0}^T\\boldsymbol{\\pi})(\\mathbf{l}^T\\boldsymbol{\\pi}) + \\sum^N_{i=2} \\exp\\left(-\\frac{k\\tau}{\\lambda_i}\\right)(\\mathbf{o}^T\\boldsymbol{\\phi}_i)(\\mathbf{\\hat p_0}^T\\boldsymbol{\\phi}_i) $$\n",
     "\n",
     "with $\\mathbf{\\hat p_0}=\\boldsymbol{\\Pi}^{-1}\\mathbf{p_0}$.\n",
     "\n",
     "\n",
-    "In PyEMMA the MSM and HMSM objects have the methods `correlation` and `relaxation` which implements calculation of auto-correlation in equilibrium and relaxation from a specified non-equilibrium distribution. Many experimental observables do not measure correlation functions directly but some quantity which depends on a correlation-function, fx its Fourier transform ([2-3](#References)). In many of these cases it is possible to obtain analytical expressions of the observable which depends only on the amplitudes $(\\mathbf{o}^T\\boldsymbol{\\phi}_i)^2$ and time-scales $t_i$, these quantities can be computed given $\\mathbf{o}$ using the `fingerprint_correlation` and `fingerprint_relaxation` methods of the MSM or HMSM objects. \n",
+    "In PyEMMA, the MSM and HMM objects have the methods `correlation` and `relaxation` which implement calculation of auto-correlation in equilibrium and relaxation from a specified nonequilibrium distribution. Many experimental observables do not measure correlation functions directly but some quantity which depends on a correlation function, or its Fourier transform ([2-3](#References)). In many of these cases it is possible to obtain analytical expressions of the observable which depends only on the amplitudes $(\\mathbf{o}^T\\boldsymbol{\\phi}_i)^2$ and time-scales $t_i$, quantities which can be computed given $\\mathbf{o}$ using the `fingerprint_correlation` and `fingerprint_relaxation` methods of the MSM or HMSM objects. \n",
     "\n",
     "We here compute the auto-correlation function of the distance between the amide and alpha protons."
    ]
@@ -729,7 +737,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The amplitude of the computed auto-correlation functions is very small. In experiments we can often prepare a non-equilibrium ensemble, and measure the relaxation back to the steady-state as discussed above. In `PyEMMA` we simulate such experiments using the `relaxation` method of the `msm` object. In addition to the arguments requried by `correlation` the `relaxation` required and initial condition $p_0$. Let's say we can prepare the 2-ALA ensemble such that it coinsides with meta-stable distribution 1, as identified by the PCCA analysis carried out above:"
+    "The amplitude of the computed auto-correlation functions is very small. In experiments, we can often prepare a nonequilibrium ensemble, and measure the relaxation back to the steady-state as discussed above. In PyEMMA, we simulate such experiments using the `relaxation` method of the `msm` object. In addition to the arguments required by `correlation`, the `relaxation` computation requires an initial condition $p_0$. Let's say we can prepare the 2-ALA ensemble such that it coincides with metastable distribution $1$, as identified by the PCCA++ analysis carried out above:"
    ]
   },
   {
@@ -783,16 +791,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Much better! This signal is orders of magnitude stronger than the one observed for the the auto-correlation function at equilibrium. \n",
+    "Much better! This signal is orders of magnitude stronger than the one observed for the auto-correlation function at equilibrium. \n",
     "### Dynamic fingerprints\n",
     "A new experiment allows us to measure the quantity:\n",
     "\n",
     "$$ \\sum_{i=2}^N \\overbrace{t_i}^{\\text{implied timescale }i} \\underbrace{(\\mathbf{o}^T\\boldsymbol{\\phi}_i)}_{\\text{Fingerprint amplitude } i}$$\n",
     "\n",
-    "For where $\\mathbf{o}$ is the distance amide and alpha protons mapped onto the Markov states (hint: this vector was computed above and is stored in the variable `dist_markov`). \n",
+    "where $\\mathbf{o}$ is the distance amide and alpha protons mapped onto the Markov states (hint: this vector was computed above and is stored in the variable `dist_markov`). \n",
     "\n",
     "#### Exercise 4\n",
-    "Using the `fingerprint_correlation` method compute the timescales and amplitudes of this new observable."
+    "Using the `fingerprint_correlation` method, compute the timescales and amplitudes of this new observable."
    ]
   },
   {
@@ -847,18 +855,18 @@
    "metadata": {},
    "source": [
     "## Wrapping up\n",
-    "In this notebook we have covered how to compute ensemble averaged properties/observables from Markov state models and hidden Markov state models. We have further covered the quantification of uncertainty in these predictions. We have specifically discussed the MSM/HMSM object methods\n",
+    "In this notebook, we have covered how to compute ensemble averaged properties/observables from Markov state models and hidden Markov state models. We have further covered the quantification of uncertainty in these predictions. We have specifically discussed the MSM/HMM object methods\n",
     "* `expectation()` computes the stationary ensemble average of a property.\n",
     "* `correlation()` computes the equilibrium auto/cross-correlation function of a/two property/properties.\n",
     "* `relaxation()` computes the relaxation auto/cross-correlation function of a/two property/properties given an initial state distribution.\n",
-    "* `fingerprint_correlation()` computes the amplitudes and time-scales of the MSM/HMSM auto/cross-correlation function.\n",
-    "* `fingerprint_relaxation()` computes the amplitudes and time-scales of the MSM/HMSM relaxation auto/cross-correlation function.\n",
-    "We have further covered the following object methods to compute statistics from Bayesian MSM/HMSMs:\n",
-    "* `sample_mean()` computes the mean of a property over the sampled MSMs/HMSMs in a Bayesian model. \n",
-    "* `sample_conf()` computes the confidence interval of a property over the sampled MSMs/HMSMs in a Bayesian model.\n",
-    "* `sample_std()` computes the standard deviation of a property over the sampled MSMs/HMSMs in a Bayesian model.\n",
+    "* `fingerprint_correlation()` computes the amplitudes and time-scales of the MSM/HMM auto/cross-correlation function.\n",
+    "* `fingerprint_relaxation()` computes the amplitudes and time-scales of the MSM/HMM relaxation auto/cross-correlation function.\n",
+    "We have further covered the following object methods to compute statistics from Bayesian MSM/HMMs:\n",
+    "* `sample_mean()` computes the mean of a property over the sampled MSMs/HMMs in a Bayesian model. \n",
+    "* `sample_conf()` computes the confidence interval of a property over the sampled MSMs/HMMs in a Bayesian model.\n",
+    "* `sample_std()` computes the standard deviation of a property over the sampled MSMs/HMMs in a Bayesian model.\n",
     "\n",
-    "Finally, we have shown how to use these methods together with precomputed observables or observables computed using third-party libraries. "
+    "Finally, we have shown how to use these methods together with precomputed observables. "
    ]
   },
   {


### PR DESCRIPTION
- fixed some typos
- removed confusing example showcasing wrong usage of stationary distribution, #115 

> "I read: "Be careful not to use the discrete probabilities as weights: you would then reweight without taking the empiricial distribution of the data into account (right panel)." - this is a little confusing to me. Maybe it helps to make explicit what's used instead? Also typo in 'empirical'."

Nota bene:
"All comas are wrong, some are useful."