### PR TITLE
fix typo

### DIFF
--- a/notebooks/00-pentapeptide-showcase.ipynb
+++ b/notebooks/00-pentapeptide-showcase.ipynb
@@ -243,7 +243,7 @@
     "the first four dimensions contain all relevant information of the slow dynamics.\n",
     "\n",
     "Based on this result, we try a TICA projection with lag time 0.5 ns (5 steps).\n",
-    "Please note that this is a modeler's choice based on the best heuristics that is currently available to our knowledge. \n",
+    "Please note that this is a modeler's choice based on the best heuristic that is currently available to our knowledge. \n",
     "It might be necessary to re-adjust the TICA lag time after the MSM estimation. \n",
     "\n",
     "\n",
@@ -350,7 +350,7 @@
     "⚠️ It is a priori unclear what the optimal number of cluster centers $k$ is.\n",
     "It largely depends on the distribution of our data and on the number of dimensions we use.\n",
     "\n",
-    "In the following, we will estimate unvalidated Markov models using different numbers of cluster centers and use the VAMP-2 score (using cross validation) as a heuristics.\n",
+    "In the following, we will estimate unvalidated Markov models using different numbers of cluster centers and use the VAMP-2 score (using cross validation) as a heuristic.\n",
     "This approach requires us to guess the MSM lag time, which we set to the TICA lag time of $5$ steps (or $0.5$ ns).\n",
     "Since the clustering algorithm is stochastic,\n",
     "we conduct multiple rounds of discretization at each number of cluster centers."
@@ -394,7 +394,7 @@
     "We will use this number for further analysis.\n",
     "\n",
     "As already stated above, the score has been generated using MSMs that were not validated,\n",
-    "meaning that the above plot is really just a heuristics.\n",
+    "meaning that the above plot is really just a heuristic.\n",
     "Besides having an optimal score, we want to obtain a model that describes physically interesting states.\n",
     "Thus, the number of states $k$ is often re-adjusted after model inspection."
    ]
@@ -531,7 +531,7 @@
     "The highest $k$ can be adjusted using the `mlags` keyword argument of `msm.cktest()`.\n",
     "\n",
     "Since we can only inspect the result for a small number of (macro-) states,\n",
-    "we use the implied timescales plot as a heuristics to estimate a number of metastable states to test for. \n",
+    "we use the implied timescales plot as a heuristic to estimate a number of metastable states to test for. \n",
     "We can resolve $4$ slow processes up to lag times of $2.5$ ns.\n",
     "Since the Chapman-Kolmogorov test involves estimations at higher lag times,\n",
     "we will attempt to capture those processes choosing $5$ metastable states."


### PR DESCRIPTION
heuristics > heuristic

it seemed like in every case we should have the singular form instead