### PR TITLE
More linking between notebook 00/06, other minor fixes.

### DIFF
--- a/notebooks/00-pentapeptide-showcase.ipynb
+++ b/notebooks/00-pentapeptide-showcase.ipynb
@@ -1002,7 +1002,7 @@
     "We find that the committor is constant within the metastable sets defined above.\n",
     "Transition regions can be identified by committor values $\\approx 0.5$.\n",
     "\n",
-    "## Computing experimental observables [➜ 📓](07-expectations-and-observables.ipynb)\n",
+    "## Computing experimental observables [➜ 📓](06-expectations-and-observables.ipynb)\n",
     "\n",
     "Having thoroughly constructed, validated, and analyzed our MSM,\n",
     "we may want to take the next step and compare our model to experimental data.\n",
@@ -1010,7 +1010,8 @@
     "below we give give some examples of this.\n",
     "We will make use of some external library functionality provided by MDTraj <a id=\"ref-9\" href=\"#cite-mdtraj\">mcgibbon-15</a>.\n",
     "\n",
-    "Theoretical backgrounds can be found here:\n",
+    "[Notebook 06](06-expectations-and-observables.ipynb) includes a brief summary of the theory used in below.\n",
+    "More in-depth descriptions of the theory and their applications to various data can be found in the following references:\n",
     "- <a id=\"ref-10\" href=\"#cite-simon-amm\">olsson-17</a>\n",
     "- <a id=\"ref-11\" href=\"#cite-noe-fingerprints\">noe-11</a>\n",
     "- <a id=\"ref-12\" href=\"#cite-simon-mech-mod-nmr\">olsson-16</a>\n",
@@ -1182,7 +1183,7 @@
    "metadata": {},
    "source": [
     "As for the stationary expectation (ensemble averages) considered above,\n",
-    "we can use our pre-computed SASA vector to compute the auto-correlation function of trypotophan flourescene using the MSM `correlation()` method:"
+    "we can use our pre-computed SASA vector to compute the auto-correlation function of trypotophan flourescene using the MSM `correlation()` method (See [Notebook 06](06-expectations-and-observables.ipynb#Dynamic/kinetic-experimental-observables) for details):"
    ]
   },
   {
@@ -1234,7 +1235,7 @@
     "Note the scale on the $y$-axis: this amplitude is likely too small to be experimentally measurable considering experimental uncertainty.\n",
     "\n",
     "However, using more advanced experimental setups such as stopped flow, T-jump, P-jump, and others,\n",
-    "we can prepare our ensemble in a non-equilibrium initial condition.\n",
+    "we can prepare our ensemble in a non-equilibrium initial condition. (See [Notebook 06](06-expectations-and-observables.ipynb#Dynamic/kinetic-experimental-observables) for details)\n",
     "\n",
     "Let us say we can experimentally prepare a sample to only be in metastable state $\\mathcal{S}_1$.\n",
     "In this case, the initial condition will be given by the metastable distribution of metastable state $\\mathcal{S}_1$, $p_0$.\n",

--- a/notebooks/06-expectations-and-observables.ipynb
+++ b/notebooks/06-expectations-and-observables.ipynb
@@ -720,6 +720,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "feat3 = pyemma.coordinates.featurizer(pdb)\n",
     "feat3.add_distances([[7, 9]], periodic=False)  # add relevant distance\n",


### PR DESCRIPTION
Reference to legacy HMM paper in notebook 00 should be changed to projected markov model paper by Frank et al.