### PR TITLE
NB08: make plot compatible with new matplotlib version

### DIFF
--- a/notebooks/08-common-problems.ipynb
+++ b/notebooks/08-common-problems.ipynb
@@ -79,10 +79,8 @@
     "    if ax is None:\n",
     "        fig, ax = plt.subplots()\n",
     "    for n, _traj in enumerate(data):\n",
-    "        h, e = np.histogram(_traj, bins=30, density=True)\n",
-    "        ax.fill_between(e[1:], h, step='pre', alpha=.33, color='C{}'.format(n))\n",
-    "    \n",
-    "    ylims = (0, ax.get_ylim()[1])\n",
+    "        ax.hist(_traj, bins=30, alpha=.33, density=True, color='C{}'.format(n));\n",
+    "    ylims = ax.get_ylim()\n",
     "    xlims = ax.get_xlim()\n",
     "    for n, _traj in enumerate(data):\n",
     "        ax.plot(\n",
@@ -100,7 +98,6 @@
     "    ax.text(0.86 * xlims[1], 0.5 * ylims[1], '$x(time)$', ha='left', va='center', rotation=90)\n",
     "    ax.set_xlabel('TICA coordinate')\n",
     "    ax.set_ylabel('histogram counts & trajectory time')\n",
-    "    ax.set_ylim(0, ax.get_ylim()[1])  # fill_between resets lower ylim < 0\n",
     "    ax.legend(loc=2)"
    ]
   },
@@ -908,7 +905,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/08-common-problems.ipynb
+++ b/notebooks/08-common-problems.ipynb
@@ -93,7 +93,7 @@
     "                np.linspace(*ylims, min(len(_traj), max_traj_length)), \n",
     "                '.-', alpha=.6, label='dtraj {}'.format(n), linewidth=.3)\n",
     "    ax.annotate(\n",
-    "        '', xy=(0.85 * xlims[1], 0.7 * ylims[1]), xytext=(0.85 * xlims[1], 0.3 * ylims[1]),\n",
+    "        '', xy=(0.8500001 * xlims[1], 0.7 * ylims[1]), xytext=(0.85 * xlims[1], 0.3 * ylims[1]),\n",
     "        arrowprops=dict(fc='C0', ec='None', alpha=0.6, width=2))\n",
     "    ax.text(0.86 * xlims[1], 0.5 * ylims[1], '$x(time)$', ha='left', va='center', rotation=90)\n",
     "    ax.set_xlabel('TICA coordinate')\n",
@@ -905,7 +905,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/08-common-problems.ipynb
+++ b/notebooks/08-common-problems.ipynb
@@ -79,8 +79,10 @@
     "    if ax is None:\n",
     "        fig, ax = plt.subplots()\n",
     "    for n, _traj in enumerate(data):\n",
-    "        ax.hist(_traj, bins=30, alpha=.33, density=True, color='C{}'.format(n));\n",
-    "    ylims = ax.get_ylim()\n",
+    "        h, e = np.histogram(_traj, bins=30, density=True)\n",
+    "        ax.fill_between(e[1:], h, step='pre', alpha=.33, color='C{}'.format(n))\n",
+    "    \n",
+    "    ylims = (0, ax.get_ylim()[1])\n",
     "    xlims = ax.get_xlim()\n",
     "    for n, _traj in enumerate(data):\n",
     "        ax.plot(\n",
@@ -98,6 +100,7 @@
     "    ax.text(0.86 * xlims[1], 0.5 * ylims[1], '$x(time)$', ha='left', va='center', rotation=90)\n",
     "    ax.set_xlabel('TICA coordinate')\n",
     "    ax.set_ylabel('histogram counts & trajectory time')\n",
+    "    ax.set_ylim(0, ax.get_ylim()[1])  # fill_between resets lower ylim < 0\n",
     "    ax.legend(loc=2)"
    ]
   },
@@ -905,7 +908,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Matplotlib functions `hist()` were not working with `annotate()` using arrow dicts (thanks @marscher).